### PR TITLE
Add coffee promo landing page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
+import Promo from "@/pages/promo";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
+      <Route path="/promos" component={Promo} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Link } from "wouter";
 
 export default function Navigation() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -53,13 +54,19 @@ export default function Navigation() {
             >
               Location
             </button>
-            <button 
-              onClick={() => scrollToSection("contact")}
-              className="text-near-black hover:text-coffee-brown transition-colors"
-            >
-              Contact
-            </button>
-          </div>
+          <button
+            onClick={() => scrollToSection("contact")}
+            className="text-near-black hover:text-coffee-brown transition-colors"
+          >
+            Contact
+          </button>
+          <Link
+            href="/promos"
+            className="text-near-black hover:text-coffee-brown transition-colors"
+          >
+            Promos
+          </Link>
+        </div>
 
           {/* Mobile Menu Button */}
           <Button
@@ -94,12 +101,19 @@ export default function Navigation() {
               >
                 Location
               </button>
-              <button 
+              <button
                 onClick={() => scrollToSection("contact")}
                 className="text-near-black hover:text-coffee-brown transition-colors text-left"
               >
                 Contact
               </button>
+              <Link
+                href="/promos"
+                className="text-near-black hover:text-coffee-brown transition-colors text-left"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Promos
+              </Link>
             </div>
           </div>
         )}

--- a/client/src/pages/promo.tsx
+++ b/client/src/pages/promo.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+
+export default function Promo() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !email) return;
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/promos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email }),
+      });
+      if (!res.ok) throw new Error("Failed to submit");
+      toast({
+        title: "Thanks for signing up!",
+        description: "We'll keep you posted on special promotions.",
+      });
+      setName("");
+      setEmail("");
+    } catch (err) {
+      toast({
+        title: "Submission failed",
+        description: "Please try again later.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-coffee-brown text-white">
+      <header className="p-6">
+        <Link href="/" className="text-warm-cream hover:underline">
+          &larr; Back to Home
+        </Link>
+      </header>
+      <main className="flex-grow flex items-center justify-center px-4">
+        <div className="bg-white/10 backdrop-blur-sm p-8 rounded-lg max-w-md w-full">
+          <h1 className="font-playfair text-4xl font-bold mb-4 text-center">
+            Join Our Coffee Lovers List
+          </h1>
+          <p className="mb-6 text-center text-warm-cream">
+            Sign up for updates on new blends and exclusive promotions.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              placeholder="Your name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="bg-white/20 border-white/30 text-white placeholder-warm-cream focus:ring-soft-mocha"
+              required
+            />
+            <Input
+              type="email"
+              placeholder="Email address"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="bg-white/20 border-white/30 text-white placeholder-warm-cream focus:ring-soft-mocha"
+              required
+            />
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-soft-mocha text-coffee-brown hover:bg-opacity-90 transition-all font-semibold"
+            >
+              {isSubmitting ? "Signing up..." : "Sign Up"}
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
+import type { Request, Response } from "express";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // put application routes here
@@ -8,6 +9,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // use storage to perform CRUD operations on the storage interface
   // e.g. storage.insertUser(user) or storage.getUserByUsername(username)
+
+  const promoSignups: { name: string; email: string }[] = [];
+
+  app.post("/api/promos", (req: Request, res: Response) => {
+    const { name, email } = req.body as { name?: string; email?: string };
+    if (!name || !email) {
+      return res.status(400).json({ message: "Name and email required" });
+    }
+    promoSignups.push({ name, email });
+    res.status(201).json({ message: "Signup recorded" });
+  });
 
   const httpServer = createServer(app);
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: import("vite").ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- add a dedicated `/promos` landing page with a signup form
- link to the landing page from the navigation bar
- save promo signups via new `/api/promos` endpoint
- fix Vite server options type to satisfy TypeScript

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68415108ea308320a70577d030578b0e